### PR TITLE
feat: Add workspace keybindings and update material theme

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -27,3 +27,7 @@ bindd = SUPER ALT, G, Google Messages, exec, hypr-launch-webapp "https://message
 # Overwrite existing bindings, like putting hypr Menu on Super + Space
 # unbind = SUPER, SPACE
 # bindd = SUPER, SPACE, hypr menu, exec, hypr-menu
+
+# Switch workspaces with Super + Ctrl + Left/Right
+bind = SUPER CTRL, left, workspace, e-1
+bind = SUPER CTRL, right, workspace, e+1

--- a/themes/material/hyprland.conf
+++ b/themes/material/hyprland.conf
@@ -1,3 +1,22 @@
 general {
-    col.active_border = rgb(2196f3)
+    # Material Blue 500
+    col.active_border = rgb(2196F3)
+    # Material Grey 800
+    col.inactive_border = rgb(424242)
+    col.nogroup_border = rgb(424242)
+    col.nogroup_border_active = rgb(2196F3)
+}
+
+group {
+    col.border_active = rgb(2196F3)
+    col.border_inactive = rgb(424242)
+    # Material Deep Orange 500
+    col.border_locked_active = rgb(FF5722)
+    col.border_locked_inactive = rgb(424242)
+}
+
+# Some other colors
+decoration {
+    # Material Grey 900
+    col.shadow = rgb(212121)
 }


### PR DESCRIPTION
This change introduces two new features to the Hyprland configuration:

1.  **New Keybindings:** Adds keybindings for `SUPER + CTRL + Left/Right` to switch between virtual desktops. This provides a more intuitive way to navigate workspaces.

2.  **Updated Material Theme:** The material theme has been updated with a more complete color palette based on the Material Design guidelines. The colors are now correctly formatted and provide a more consistent look and feel.