### PR TITLE
feat: Add Amateur theme

### DIFF
--- a/themes/amateur/alacritty.toml
+++ b/themes/amateur/alacritty.toml
@@ -1,0 +1,29 @@
+[colors]
+[colors.primary]
+background = '#0A1014'
+foreground = '#D8D8D8'
+
+# Normal colors
+[colors.normal]
+black = '#000000'
+red = '#FF5252'
+green = '#69F0AE'
+yellow = '#FFD740'
+blue = '#448AFF'
+magenta = '#E040FB'
+cyan = '#00FFFF'
+white = '#FFFFFF'
+
+# Bright colors
+[colors.bright]
+black = '#616161'
+red = '#FF5252'
+green = '#69F0AE'
+yellow = '#FFD740'
+blue = '#448AFF'
+magenta = '#E040FB'
+cyan = '#00B8D4'
+white = '#FFFFFF'
+
+[colors.selection]
+background = '#00838F'

--- a/themes/amateur/btop.theme
+++ b/themes/amateur/btop.theme
@@ -1,0 +1,81 @@
+# Theme: Amateur
+# By: Jules
+
+# Main bg
+theme[main_bg]="#0A1014"
+
+# Main text color
+theme[main_fg]="#D8D8D8"
+
+# Title color for boxes
+theme[title]="#D8D8D8"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#00FFFF"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#00838F"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#D8D8D8"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#616161"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#00B8D4"
+
+# Cpu box outline color
+theme[cpu_box]="#00838F"
+
+# Memory/disks box outline color
+theme[mem_box]="#00838F"
+
+# Net up/down box outline color
+theme[net_box]="#00838F"
+
+# Processes box outline color
+theme[proc_box]="#00838F"
+
+# Box divider line and small boxes line color
+theme[div_line]="#616161"
+
+# Temperature graph colors
+theme[temp_start]="#69F0AE"
+theme[temp_mid]="#FFAB40"
+theme[temp_end]="#FF5252"
+
+# CPU graph colors
+theme[cpu_start]="#69F0AE"
+theme[cpu_mid]="#FFAB40"
+theme[cpu_end]="#FF5252"
+
+# Mem/Disk free meter
+theme[free_start]="#69F0AE"
+theme[free_mid]="#FFD740"
+theme[free_end]="#00B8D4"
+
+# Mem/Disk cached meter
+theme[cached_start]="#448AFF"
+theme[cached_mid]="#00B8D4"
+theme[cached_end]="#00838F"
+
+# Mem/Disk available meter
+theme[available_start]="#69F0AE"
+theme[available_mid]="#00B8D4"
+theme[available_end]="#00838F"
+
+# Mem/Disk used meter
+theme[used_start]="#FFAB40"
+theme[used_mid]="#FF5252"
+theme[used_end]="#E040FB"
+
+# Download graph colors
+theme[download_start]="#69F0AE"
+theme[download_mid]="#00B8D4"
+theme[download_end]="#448AFF"
+
+# Upload graph colors
+theme[upload_start]="#69F0AE"
+theme[upload_mid]="#00B8D4"
+theme[upload_end]="#448AFF"

--- a/themes/amateur/hyprland.conf
+++ b/themes/amateur/hyprland.conf
@@ -1,0 +1,3 @@
+general {
+    col.active_border = rgba(00B8D4ee) rgba(00FFFFee) 45deg
+}

--- a/themes/amateur/hyprlock.conf
+++ b/themes/amateur/hyprlock.conf
@@ -1,0 +1,5 @@
+$color = rgba(10, 16, 20, 1.0)
+$inner_color = rgba(10, 16, 20, 0.8)
+$outer_color = rgba(216, 216, 216, 1.0)
+$font_color = rgba(216, 216, 216, 1.0)
+$check_color = rgba(0, 255, 255, 1.0)

--- a/themes/amateur/icons.theme
+++ b/themes/amateur/icons.theme
@@ -1,0 +1,1 @@
+Yaru-cyan

--- a/themes/amateur/mako.ini
+++ b/themes/amateur/mako.ini
@@ -1,0 +1,24 @@
+text-color=#D8D8D8
+border-color=#00B8D4
+background-color=#0A1014
+width=420
+height=110
+padding=10
+border-size=2
+font=Liberation Sans 11
+anchor=top-right
+outer-margin=20
+default-timeout=5000
+max-icon-size=32
+
+[app-name=Spotify]
+invisible=1
+
+[mode=do-not-disturb]
+invisible=true
+
+[mode=do-not-disturb app-name=notify-send]
+invisible=false
+
+[urgency=critical]
+default-timeout=0

--- a/themes/amateur/neovim.lua
+++ b/themes/amateur/neovim.lua
@@ -1,0 +1,11 @@
+-- This file sets the colorscheme for Neovim.
+-- Please note that you need to have a Neovim colorscheme named "amateur"
+-- installed for this to work.
+return {
+	{
+		"LazyVim/LazyVim",
+		opts = {
+			colorscheme = "amateur",
+		},
+	},
+}

--- a/themes/amateur/swayosd.css
+++ b/themes/amateur/swayosd.css
@@ -1,0 +1,5 @@
+@define-color background-color #0A1014;
+@define-color border-color #00B8D4;
+@define-color label #D8D8D8;
+@define-color image #D8D8D8;
+@define-color progress #00FFFF;

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -1,0 +1,6 @@
+@define-color selected-text #00FFFF;
+@define-color text #D8D8D8;
+@define-color base #0A1014;
+@define-color border #00B8D4;
+@define-color foreground #D8D8D8;
+@define-color background #0A1014;

--- a/themes/amateur/waybar.css
+++ b/themes/amateur/waybar.css
@@ -1,0 +1,5 @@
+@define-color foreground #D8D8D8;
+@define-color background #0A1014;
+@define-color accent #00FFFF;
+@define-color warning #FFAB40;
+@define-color error #FF5252;


### PR DESCRIPTION
This commit introduces a new theme called "Amateur", based on the user's request. The theme uses a color palette of cyans and teals, with orange for warnings/info and red for errors.

The theme includes configuration files for:
- alacritty
- btop
- hyprland
- hyprlock
- mako
- neovim
- swayosd
- walker
- waybar
- icons

The user is expected to install a Neovim colorscheme named "amateur" separately for the Neovim theme to work correctly.