### PR TITLE
feat: Revise Amateur theme

### DIFF
--- a/themes/amateur/alacritty.toml
+++ b/themes/amateur/alacritty.toml
@@ -5,25 +5,26 @@ foreground = '#D8D8D8'
 
 # Normal colors
 [colors.normal]
-black = '#000000'
+black = '#1E2228'
 red = '#FF5252'
-green = '#69F0AE'
-yellow = '#FFD740'
+green = '#00B8D4'
+yellow = '#FFAB40'
 blue = '#448AFF'
 magenta = '#E040FB'
 cyan = '#00FFFF'
-white = '#FFFFFF'
+white = '#D8D8D8'
 
 # Bright colors
 [colors.bright]
 black = '#616161'
-red = '#FF5252'
+red = '#FF8A80'
 green = '#69F0AE'
 yellow = '#FFD740'
-blue = '#448AFF'
-magenta = '#E040FB'
-cyan = '#00B8D4'
+blue = '#82B1FF'
+magenta = '#EA80FC'
+cyan = '#A7FFEB'
 white = '#FFFFFF'
 
 [colors.selection]
-background = '#00838F'
+background = '#00B8D4'
+foreground = '#FFFFFF'

--- a/themes/amateur/btop.theme
+++ b/themes/amateur/btop.theme
@@ -1,4 +1,4 @@
-# Theme: Amateur
+# Theme: Amateur (Revised)
 # By: Jules
 
 # Main bg
@@ -8,74 +8,74 @@ theme[main_bg]="#0A1014"
 theme[main_fg]="#D8D8D8"
 
 # Title color for boxes
-theme[title]="#D8D8D8"
+theme[title]="#A7FFEB" # Bright Cyan
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#00FFFF"
+theme[hi_fg]="#00FFFF" # Cyan
 
 # Background color of selected item in processes box
-theme[selected_bg]="#00838F"
+theme[selected_bg]="#00B8D4" # Teal
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#D8D8D8"
+theme[selected_fg]="#FFFFFF"
 
 # Color of inactive/disabled text
 theme[inactive_fg]="#616161"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#00B8D4"
+theme[proc_misc]="#00B8D4" # Teal
 
 # Cpu box outline color
-theme[cpu_box]="#00838F"
+theme[cpu_box]="#FFAB40" # Orange
 
 # Memory/disks box outline color
-theme[mem_box]="#00838F"
+theme[mem_box]="#448AFF" # Blue
 
 # Net up/down box outline color
-theme[net_box]="#00838F"
+theme[net_box]="#69F0AE" # Green
 
 # Processes box outline color
-theme[proc_box]="#00838F"
+theme[proc_box]="#00FFFF" # Cyan
 
 # Box divider line and small boxes line color
 theme[div_line]="#616161"
 
 # Temperature graph colors
 theme[temp_start]="#69F0AE"
-theme[temp_mid]="#FFAB40"
+theme[temp_mid]="#FFD740"
 theme[temp_end]="#FF5252"
 
 # CPU graph colors
-theme[cpu_start]="#69F0AE"
+theme[cpu_start]="#00B8D4"
 theme[cpu_mid]="#FFAB40"
 theme[cpu_end]="#FF5252"
 
 # Mem/Disk free meter
 theme[free_start]="#69F0AE"
-theme[free_mid]="#FFD740"
-theme[free_end]="#00B8D4"
+theme[free_mid]="#A7FFEB"
+theme[free_end]="#00FFFF"
 
 # Mem/Disk cached meter
 theme[cached_start]="#448AFF"
-theme[cached_mid]="#00B8D4"
-theme[cached_end]="#00838F"
+theme[cached_mid]="#82B1FF"
+theme[cached_end]="#A7FFEB"
 
 # Mem/Disk available meter
 theme[available_start]="#69F0AE"
-theme[available_mid]="#00B8D4"
-theme[available_end]="#00838F"
+theme[available_mid]="#A7FFEB"
+theme[available_end]="#00FFFF"
 
 # Mem/Disk used meter
 theme[used_start]="#FFAB40"
-theme[used_mid]="#FF5252"
-theme[used_end]="#E040FB"
+theme[used_mid]="#FF8A80"
+theme[used_end]="#FF5252"
 
 # Download graph colors
-theme[download_start]="#69F0AE"
-theme[download_mid]="#00B8D4"
-theme[download_end]="#448AFF"
+theme[download_start]="#00B8D4"
+theme[download_mid]="#448AFF"
+theme[download_end]="#82B1FF"
 
 # Upload graph colors
 theme[upload_start]="#69F0AE"
-theme[upload_mid]="#00B8D4"
-theme[upload_end]="#448AFF"
+theme[upload_mid]="#A7FFEB"
+theme[upload_end]="#00FFFF"

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -4,3 +4,72 @@
 @define-color border #00B8D4;
 @define-color foreground #D8D8D8;
 @define-color background #0A1014;
+@define-color orange #FFAB40;
+
+* {
+    font-family: "CaskaydiaMono Nerd Font";
+    font-size: 14px;
+}
+
+window {
+    background-color: @background;
+    border: 2px solid @border;
+    border-radius: 10px;
+}
+
+#input {
+    margin: 5px;
+    border: none;
+    color: @foreground;
+    background-color: @background;
+    border-bottom: 2px solid @orange;
+}
+
+#inner-box {
+    margin: 5px;
+    border: none;
+    background-color: @background;
+}
+
+#outer-box {
+    margin: 5px;
+    border: none;
+    background-color: @background;
+}
+
+#scroll {
+    margin: 0px;
+    border: none;
+}
+
+#text {
+    margin: 5px;
+    border: none;
+    color: @text;
+}
+
+#entry:selected {
+    background-color: @border;
+    color: @background;
+    border-radius: 5px;
+}
+
+#entry:selected #text {
+    color: @background;
+}
+
+@keyframes pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(0, 255, 255, 0.4);
+    }
+    70% {
+        box-shadow: 0 0 0 10px rgba(0, 255, 255, 0);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(0, 255, 255, 0);
+    }
+}
+
+#entry:selected {
+    animation: pulse 1s infinite;
+}

--- a/themes/amateur/waybar.css
+++ b/themes/amateur/waybar.css
@@ -1,5 +1,153 @@
 @define-color foreground #D8D8D8;
 @define-color background #0A1014;
-@define-color accent #00FFFF;
-@define-color warning #FFAB40;
-@define-color error #FF5252;
+@define-color cyan #00FFFF;
+@define-color teal #00B8D4;
+@define-color dark-teal #00838F;
+@define-color orange #FFAB40;
+@define-color bright-orange #FFD180;
+@define-color dark-orange #FF9100;
+@define-color red #FF5252;
+@define-color blue #448AFF;
+@define-color green #69F0AE;
+
+window#waybar {
+    background-color: @background;
+    color: @foreground;
+    transition-property: background-color;
+    transition-duration: .5s;
+}
+
+button {
+    /* Use box-shadow instead of border so the text isn't offset */
+    box-shadow: inset 0 -3px transparent;
+    /* Avoid rounded borders under each button */
+    border: none;
+    border-radius: 0;
+}
+
+button:hover {
+    background: inherit;
+    box-shadow: inset 0 -3px @cyan;
+}
+
+#workspaces button {
+    padding: 0 5px;
+    background-color: transparent;
+    color: @foreground;
+}
+
+#workspaces button:hover {
+    background: rgba(0, 0, 0, 0.2);
+}
+
+#workspaces button.focused {
+    background-color: @dark-teal;
+    box-shadow: inset 0 -3px @cyan;
+}
+
+#workspaces button.urgent {
+    background-color: @orange;
+    color: @background;
+}
+
+#mode {
+    background-color: @red;
+    border-bottom: 3px solid @foreground;
+    color: @foreground;
+}
+
+#clock,
+#battery,
+#cpu,
+#memory,
+#disk,
+#temperature,
+#backlight,
+#network,
+#pulseaudio,
+#custom-media {
+    padding: 0 10px;
+    color: @foreground;
+}
+
+#clock {
+    background-color: @teal;
+    color: @background;
+}
+
+#battery {
+    background-color: @green;
+    color: @background;
+}
+
+#battery.charging, #battery.plugged {
+    color: @background;
+    background-color: @blue;
+}
+
+@keyframes blink {
+    to {
+        background-color: @red;
+        color: @background;
+    }
+}
+
+#battery.critical:not(.charging) {
+    background-color: @red;
+    color: @background;
+    animation-name: blink;
+    animation-duration: 0.5s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
+}
+
+label:focus {
+    background-color: @background;
+}
+
+#cpu {
+    background-color: @orange;
+    color: @background;
+}
+
+#memory {
+    background-color: @bright-orange;
+    color: @background;
+}
+
+#disk {
+    background-color: @dark-orange;
+}
+
+#network {
+    background-color: @blue;
+}
+
+#network.disconnected {
+    background-color: @red;
+}
+
+#pulseaudio {
+    background-color: #E040FB; /* magenta */
+    color: @background;
+}
+
+#pulseaudio.muted {
+    background-color: #616161; /* grey */
+    color: @foreground;
+}
+
+#custom-media {
+    background-color: @teal;
+    color: @background;
+    min-width: 100px;
+}
+
+#temperature {
+    background-color: @orange;
+}
+
+#temperature.critical {
+    background-color: @red;
+}


### PR DESCRIPTION
This commit revises the "Amateur" theme based on user feedback to be more vibrant and make better use of accent colors.

The following files have been updated:
- themes/amateur/waybar.css
- themes/amateur/alacritty.toml
- themes/amateur/btop.theme
- themes/amateur/walker.css

The updated theme now has a more dynamic and visually appealing design, with a wider range of colors used for different UI elements.