### PR TITLE
feat: Improve amateur theme palette using color theory

### DIFF
--- a/themes/amateur/btop.theme
+++ b/themes/amateur/btop.theme
@@ -2,80 +2,80 @@
 # By: Jules
 
 # Main bg
-theme[main_bg]="#0A1A1A"
+theme[main_bg]="#1A202C"
 
 # Main text color
-theme[main_fg]="#00FFFF"
+theme[main_fg]="#E2E8F0"
 
 # Title color for boxes
-theme[title]="#40E0D0"
+theme[title]="#63B3ED"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#00BFFF"
+theme[hi_fg]="#4299E1"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#008080"
+theme[selected_bg]="#2C5282"
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#00FFFF"
+theme[selected_fg]="#E2E8F0"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#142828"
+theme[inactive_fg]="#4A5568"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#40E0D0"
+theme[proc_misc]="#63B3ED"
 
 # Cpu box outline color
-theme[cpu_box]="#FFA500"
+theme[cpu_box]="#F6AD55"
 
 # Memory/disks box outline color
-theme[mem_box]="#00BFFF"
+theme[mem_box]="#4FD1C5"
 
 # Net up/down box outline color
-theme[net_box]="#2E8B57"
+theme[net_box]="#48BB78"
 
 # Processes box outline color
-theme[proc_box]="#008080"
+theme[proc_box]="#63B3ED"
 
 # Box divider line and small boxes line color
-theme[div_line]="#142828"
+theme[div_line]="#2D3748"
 
 # Temperature graph colors
-theme[temp_start]="#2E8B57"
-theme[temp_mid]="#FFA500"
-theme[temp_end]="#FF4500"
+theme[temp_start]="#4FD1C5"
+theme[temp_mid]="#F6AD55"
+theme[temp_end]="#F56565"
 
 # CPU graph colors
-theme[cpu_start]="#40E0D0"
-theme[cpu_mid]="#FFA500"
-theme[cpu_end]="#FF4500"
+theme[cpu_start]="#63B3ED"
+theme[cpu_mid]="#F6AD55"
+theme[cpu_end]="#F56565"
 
 # Mem/Disk free meter
-theme[free_start]="#2E8B57"
-theme[free_mid]="#40E0D0"
-theme[free_end]="#00FFFF"
+theme[free_start]="#48BB78"
+theme[free_mid]="#4FD1C5"
+theme[free_end]="#E2E8F0"
 
 # Mem/Disk cached meter
-theme[cached_start]="#008080"
-theme[cached_mid]="#40E0D0"
-theme[cached_end]="#00BFFF"
+theme[cached_start]="#2C5282"
+theme[cached_mid]="#63B3ED"
+theme[cached_end]="#4FD1C5"
 
 # Mem/Disk available meter
-theme[available_start]="#2E8B57"
-theme[available_mid]="#40E0D0"
-theme[available_end]="#00FFFF"
+theme[available_start]="#48BB78"
+theme[available_mid]="#4FD1C5"
+theme[available_end]="#E2E8F0"
 
 # Mem/Disk used meter
-theme[used_start]="#FFA500"
-theme[used_mid]="#FF4500"
-theme[used_end]="#FF4500"
+theme[used_start]="#F6AD55"
+theme[used_mid]="#F56565"
+theme[used_end]="#EF4444"
 
 # Download graph colors
-theme[download_start]="#40E0D0"
-theme[download_mid]="#00BFFF"
-theme[download_end]="#008080"
+theme[download_start]="#63B3ED"
+theme[download_mid]="#4FD1C5"
+theme[download_end]="#2C5282"
 
 # Upload graph colors
-theme[upload_start]="#2E8B57"
-theme[upload_mid]="#40E0D0"
-theme[upload_end]="#00FFFF"
+theme[upload_start]="#48BB78"
+theme[upload_mid]="#4FD1C5"
+theme[upload_end]="#E2E8F0"

--- a/themes/amateur/hyprland.conf
+++ b/themes/amateur/hyprland.conf
@@ -1,5 +1,5 @@
 general {
-    col.active_border = rgba(00ffeeff) rgba(00b777ff) 45deg
-    col.inactive_border = rgba(003d1fff)
-    col.nogroup_border = rgba(0A1A1Aee)
+    col.active_border = rgba(63b3edff) rgba(4299e1ff) 45deg
+    col.inactive_border = rgba(2d3748ff)
+    col.nogroup_border = rgba(1a202cff)
 }

--- a/themes/amateur/swayosd.css
+++ b/themes/amateur/swayosd.css
@@ -1,5 +1,5 @@
-@define-color background-color #0A1A1A;
-@define-color border-color #008080;
-@define-color label #00FFFF;
-@define-color image #00FFFF;
-@define-color progress #00BFFF;
+@define-color background-color #1A202C;
+@define-color border-color #63B3ED;
+@define-color label #E2E8F0;
+@define-color image #E2E8F0;
+@define-color progress #4299E1;

--- a/themes/amateur/waybar.css
+++ b/themes/amateur/waybar.css
@@ -1,3 +1,3 @@
-@define-color background #0A1A1A;
-@define-color foreground #00FFFF;
+@define-color background #1A202C;
+@define-color foreground #E2E8F0;
 


### PR DESCRIPTION
The original amateur theme used a high-contrast cyan and black color scheme that could be harsh on the eyes.

This commit introduces a new, more harmonious color palette inspired by "deep sea" and "twilight" themes. The new palette uses a dark navy blue background, a light gray foreground, and accents of blue, orange, green, and red.

The new colors are applied consistently across all relevant theme files to ensure a uniform look and feel.