### PR TITLE
feat(theme): update vancouver theme colors

### DIFF
--- a/themes/vancouver/alacritty.toml
+++ b/themes/vancouver/alacritty.toml
@@ -1,30 +1,30 @@
 [colors]
 [colors.primary]
-background = '#1b2425'
-foreground = '#7ab9a9'
+background = '#004170'
+foreground = '#ffffff'
 
 # Normal colors
 [colors.normal]
-black = '#2D3748'
+black = '#004170'
 red = '#F56565'
-green = '#3edf81'
+green = '#2d4e00'
 yellow = '#F6AD55'
-blue = '#63B3ED'
-magenta = '#4FD1C5'
-cyan = '#4FD1C5'
-white = '#E2E8F0'
+blue = '#32668c'
+magenta = '#32668c'
+cyan = '#32668c'
+white = '#ffffff'
 
 # Bright colors
 [colors.bright]
-black = '#4A5568'
-red = '#EF4444'
-green = '#38A169'
+black = '#ced4d8'
+red = '#F56565'
+green = '#2d4e00'
 yellow = '#F6AD55'
-blue = '#4299E1'
-magenta = '#4FD1C5'
-cyan = '#4FD1C5'
-white = '#F7FAFC'
+blue = '#32668c'
+magenta = '#32668c'
+cyan = '#32668c'
+white = '#ffffff'
 
 [colors.selection]
-background = '#2C5282'
-foreground = '#E2E8F0'
+background = '#32668c'
+foreground = '#ffffff'

--- a/themes/vancouver/colors/vancouver.lua
+++ b/themes/vancouver/colors/vancouver.lua
@@ -1,22 +1,22 @@
--- themes/vancouver/colors/amateur.lua
+-- themes/vancouver/colors/vancouver.lua
 
 -- Set the colorscheme name
 vim.g.colors_name = "vancouver"
 
 -- Get the color palette
 local colors = {
-	bg = "#1A202C",
-	fg = "#E2E8F0",
-	gray = "#4A5568",
+	bg = "#004170",
+	fg = "#ffffff",
+	gray = "#ced4d8",
 	red = "#F56565",
-	green = "#48BB78",
+	green = "#2d4e00",
 	yellow = "#F6AD55",
-	blue = "#63B3ED",
-	magenta = "#4FD1C5",
-	cyan = "#4FD1C5",
-	white = "#F7FAFC",
+	blue = "#32668c",
+	magenta = "#32668c",
+	cyan = "#32668c",
+	white = "#ffffff",
 	orange = "#F6AD55",
-	dark_blue = "#2C5282",
+	dark_blue = "#004170",
 }
 
 -- Helper function to set highlights

--- a/themes/vancouver/waybar.css
+++ b/themes/vancouver/waybar.css
@@ -1,3 +1,3 @@
-@define-color background #1A202C;
-@define-color foreground #E2E8F0;
+@define-color background #004170;
+@define-color foreground #ffffff;
 


### PR DESCRIPTION
Updates the color palette for the vancouver theme.

The new color palette is based on a "vancouver" theme and includes shades of blue, green, and white.

The following files were updated:
- themes/vancouver/colors/vancouver.lua
- themes/vancouver/waybar.css
- themes/vancouver/alacritty.toml