### PR TITLE
feat(theme): update vancouver theme to autumn palette

### DIFF
--- a/themes/vancouver/alacritty.toml
+++ b/themes/vancouver/alacritty.toml
@@ -1,30 +1,30 @@
 [colors]
 [colors.primary]
-background = '#0a1a3a'
+background = '#2a2a2a'
 foreground = '#f0f0f0'
 
 # Normal colors
 [colors.normal]
-black = '#0a1a3a'
+black = '#2a2a2a'
 red = '#f04a4a'
 green = '#1a3a1a'
 yellow = '#f0c04a'
-blue = '#1a3a7a'
+blue = '#5a3a1a'
 magenta = '#f04a4a'
 cyan = '#4af0f0'
 white = '#f0f0f0'
 
 # Bright colors
 [colors.bright]
-black = '#4a4a4a'
+black = '#5a5a5a'
 red = '#f04a4a'
 green = '#1a3a1a'
 yellow = '#f0c04a'
-blue = '#1a3a7a'
+blue = '#5a3a1a'
 magenta = '#f04a4a'
 cyan = '#4af0f0'
 white = '#f0f0f0'
 
 [colors.selection]
-background = '#1a3a7a'
+background = '#5a5a5a'
 foreground = '#f0f0f0'

--- a/themes/vancouver/btop.theme
+++ b/themes/vancouver/btop.theme
@@ -2,43 +2,43 @@
 # By: Jules
 
 # Main bg
-theme[main_bg]="#0a1a3a"
+theme[main_bg]="#2a2a2a"
 
 # Main text color
 theme[main_fg]="#f0f0f0"
 
 # Title color for boxes
-theme[title]="#f0c04a"
+theme[title]="#d98c4a"
 
 # Highlight color for keyboard shortcuts
 theme[hi_fg]="#4af0f0"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#1a3a7a"
+theme[selected_bg]="#5a5a5a"
 
 # Foreground color of selected item in processes box
 theme[selected_fg]="#f0f0f0"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#4a4a4a"
+theme[inactive_fg]="#5a5a5a"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
 theme[proc_misc]="#f0c04a"
 
 # Cpu box outline color
-theme[cpu_box]="#4af0f0"
+theme[cpu_box]="#d98c4a"
 
 # Memory/disks box outline color
-theme[mem_box]="#4af0f0"
+theme[mem_box]="#f0c04a"
 
 # Net up/down box outline color
-theme[net_box]="#4af0f0"
+theme[net_box]="#f04a4a"
 
 # Processes box outline color
 theme[proc_box]="#4af0f0"
 
 # Box divider line and small boxes line color
-theme[div_line]="#4a4a4a"
+theme[div_line]="#5a5a5a"
 
 # Temperature graph colors
 theme[temp_start]="#1a3a1a"
@@ -56,9 +56,9 @@ theme[free_mid]="#f0c04a"
 theme[free_end]="#f0f0f0"
 
 # Mem/Disk cached meter
-theme[cached_start]="#1a3a7a"
-theme[cached_mid]="#f0c04a"
-theme[cached_end]="#4af0f0"
+theme[cached_start]="#5a3a1a"
+theme[cached_mid]="#d98c4a"
+theme[cached_end]="#f0c04a"
 
 # Mem/Disk available meter
 theme[available_start]="#1a3a1a"
@@ -66,16 +66,16 @@ theme[available_mid]="#f0c04a"
 theme[available_end]="#f0f0f0"
 
 # Mem/Disk used meter
-theme[used_start]="#f0c04a"
+theme[used_start]="#d98c4a"
 theme[used_mid]="#f04a4a"
 theme[used_end]="#f04a4a"
 
 # Download graph colors
-theme[download_start]="#1a3a7a"
+theme[download_start]="#5a3a1a"
 theme[download_mid]="#1a3a1a"
-theme[download_end]="#0a1a3a"
+theme[download_end]="#2a2a2a"
 
 # Upload graph colors
 theme[upload_start]="#1a3a1a"
-theme[upload_mid]="#1a3a7a"
+theme[upload_mid]="#5a3a1a"
 theme[upload_end]="#f0f0f0"

--- a/themes/vancouver/colors/vancouver.lua
+++ b/themes/vancouver/colors/vancouver.lua
@@ -5,18 +5,18 @@ vim.g.colors_name = "vancouver"
 
 -- Get the color palette
 local colors = {
-	bg = "#0a1a3a",
+	bg = "#2a2a2a",
 	fg = "#f0f0f0",
-	gray = "#4a4a4a",
+	gray = "#5a5a5a",
 	red = "#f04a4a",
 	green = "#1a3a1a",
 	yellow = "#f0c04a",
-	blue = "#1a3a7a",
+	blue = "#5a3a1a",
 	magenta = "#f04a4a",
 	cyan = "#4af0f0",
 	white = "#f0f0f0",
-	orange = "#f0c04a",
-	dark_blue = "#0a1a3a",
+	orange = "#d98c4a",
+	dark_blue = "#2a2a2a",
 }
 
 -- Helper function to set highlights
@@ -41,6 +41,6 @@ s("Visual", { bg = colors.dark_blue })
 s("Search", { bg = colors.yellow, fg = colors.bg })
 s("IncSearch", { bg = colors.orange, fg = colors.bg })
 s("DiffAdd", { bg = "#1a3a1a" })
-s("DiffChange", { bg = "#1a3a7a" })
+s("DiffChange", { bg = "#5a3a1a" })
 s("DiffDelete", { bg = "#f04a4a" })
 s("DiffText", { bg = "#f0c04a" })

--- a/themes/vancouver/hyprland.conf
+++ b/themes/vancouver/hyprland.conf
@@ -1,5 +1,5 @@
 general {
-    col.active_border = rgba(4af0f0ff) rgba(f0c04aff) 45deg
-    col.inactive_border = rgba(4a4a4aff)
-    col.nogroup_border = rgba(0a1a3aff)
+    col.active_border = rgba(4af0f0ff) rgba(d98c4aff) 45deg
+    col.inactive_border = rgba(5a5a5aff)
+    col.nogroup_border = rgba(2a2a2aff)
 }

--- a/themes/vancouver/hyprlock.conf
+++ b/themes/vancouver/hyprlock.conf
@@ -1,5 +1,5 @@
-$color = rgba(10, 26, 58, 1.0)
-$inner_color = rgba(10, 26, 58, 0.8)
+$color = rgba(42, 42, 42, 1.0)
+$inner_color = rgba(42, 42, 42, 0.8)
 $outer_color = rgba(74, 240, 240, 1.0)
 $font_color = rgba(240, 240, 240, 1.0)
 $check_color = rgba(240, 240, 240, 1.0)

--- a/themes/vancouver/mako.ini
+++ b/themes/vancouver/mako.ini
@@ -1,6 +1,6 @@
 text-color=#f0f0f0
 border-color=#4af0f0
-background-color=#0a1a3a
+background-color=#2a2a2a
 width=420
 height=110
 padding=10

--- a/themes/vancouver/swayosd.css
+++ b/themes/vancouver/swayosd.css
@@ -1,5 +1,5 @@
-@define-color background-color #0a1a3a;
+@define-color background-color #2a2a2a;
 @define-color border-color #4af0f0;
 @define-color label #f0f0f0;
 @define-color image #f0f0f0;
-@define-color progress #f0c04a;
+@define-color progress #d98c4a;

--- a/themes/vancouver/walker.css
+++ b/themes/vancouver/walker.css
@@ -1,6 +1,6 @@
 @define-color selected-text #4af0f0;
 @define-color text #f0f0f0;
-@define-color base #0a1a3a;
+@define-color base #2a2a2a;
 @define-color border #4af0f0;
 @define-color foreground #f0f0f0;
-@define-color background #0a1a3a;
+@define-color background #2a2a2a;

--- a/themes/vancouver/waybar.css
+++ b/themes/vancouver/waybar.css
@@ -1,3 +1,3 @@
-@define-color background #0a1a3a;
+@define-color background #2a2a2a;
 @define-color foreground #f0f0f0;
 


### PR DESCRIPTION
Updates the color palette for the vancouver theme to an 'autumn from image' palette, as requested.

The new color palette is based on the warm, autumn colors from the city lights in the `1-vancouver.jpg` image, with less emphasis on the blue tones from the sky and water.

All relevant files in the `themes/vancouver` directory have been updated to use the new color palette.