### PR TITLE
feat: Update walker theming and command flag

### DIFF
--- a/bin/hypr-menu
+++ b/bin/hypr-menu
@@ -18,7 +18,7 @@ menu() {
         fi
     fi
 
-    echo -e "$options" | walker -dmenu -p "$prompt…" "${args[@]}"
+    echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"
 }
 
 terminal() {

--- a/bin/hypr-theme-set
+++ b/bin/hypr-theme-set
@@ -58,10 +58,17 @@ fi
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 
+# Make sure walker theme directory exists
+mkdir -p ~/.config/walker/themes
+
+# Set walker theme
+ln -snf ~/.config/hypr/current/theme/walker.css ~/.config/walker/themes/current.css
+
 # Restart components to apply new theme
 pkill -SIGUSR2 btop
 hypr-restart-waybar
 hypr-restart-swayosd
+hypr-restart-walker
 makoctl reload
 hyprctl reload
 

--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -1,7 +1,7 @@
 close_when_open = true
 force_keyboard_focus = true
 selection_wrap = true
-theme = "hypr-default"
+theme = "current"
 
 [shell]
 anchor_top = true

--- a/themes/adwaita-dark/walker.css
+++ b/themes/adwaita-dark/walker.css
@@ -1,0 +1,4 @@
+@define-color base #242424;
+@define-color text #ffffff;
+@define-color border #ffffff;
+@define-color selected-text #78aeed;

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -1,0 +1,4 @@
+@define-color base #1A202C;
+@define-color text #E2E8F0;
+@define-color border #E2E8F0;
+@define-color selected-text #00eacb;

--- a/themes/catppuccin-latte/walker.css
+++ b/themes/catppuccin-latte/walker.css
@@ -1,0 +1,4 @@
+@define-color base #eff1f5;
+@define-color text #4c4f69;
+@define-color border #4c4f69;
+@define-color selected-text #1e66f5;

--- a/themes/catppuccin/walker.css
+++ b/themes/catppuccin/walker.css
@@ -1,0 +1,4 @@
+@define-color base #24273a;
+@define-color text #c6d0f5;
+@define-color border #c6d0f5;
+@define-color selected-text #8caaee;

--- a/themes/everforest/walker.css
+++ b/themes/everforest/walker.css
@@ -1,0 +1,4 @@
+@define-color base #2d353b;
+@define-color text #d3c6aa;
+@define-color border #d3c6aa;
+@define-color selected-text #dbbc7f;

--- a/themes/gruvbox/walker.css
+++ b/themes/gruvbox/walker.css
@@ -1,0 +1,4 @@
+@define-color base #282828;
+@define-color text #ebdbb2;
+@define-color border #ebdbb2;
+@define-color selected-text #fabd2f;

--- a/themes/kanagawa/walker.css
+++ b/themes/kanagawa/walker.css
@@ -1,0 +1,4 @@
+@define-color base #1f1f28;
+@define-color text #dcd7ba;
+@define-color border #dcd7ba;
+@define-color selected-text #dca561;

--- a/themes/material/walker.css
+++ b/themes/material/walker.css
@@ -1,0 +1,4 @@
+@define-color base #263238;
+@define-color text #B0BEC5;
+@define-color border #B0BEC5;
+@define-color selected-text #009688;

--- a/themes/matte-black/walker.css
+++ b/themes/matte-black/walker.css
@@ -1,0 +1,4 @@
+@define-color base #121212;
+@define-color text #EAEAEA;
+@define-color border #EAEAEA;
+@define-color selected-text #B91C1C;

--- a/themes/nord/walker.css
+++ b/themes/nord/walker.css
@@ -1,0 +1,4 @@
+@define-color base #2E3440;
+@define-color text #D8DEE9;
+@define-color border #D8DEE9;
+@define-color selected-text #88C0D0;

--- a/themes/osaka-jade/walker.css
+++ b/themes/osaka-jade/walker.css
@@ -1,0 +1,4 @@
+@define-color base #11221C;
+@define-color text #ebfff2;
+@define-color border #ebfff2;
+@define-color selected-text #e1b55e;

--- a/themes/ristretto/walker.css
+++ b/themes/ristretto/walker.css
@@ -1,0 +1,4 @@
+@define-color base #2c2525;
+@define-color text #e6d9db;
+@define-color border #e6d9db;
+@define-color selected-text #fabd2f;

--- a/themes/rose-pine/walker.css
+++ b/themes/rose-pine/walker.css
@@ -1,0 +1,4 @@
+@define-color base #faf4ed;
+@define-color text #575279;
+@define-color border #575279;
+@define-color selected-text #88C0D0;

--- a/themes/tokyo-night/walker.css
+++ b/themes/tokyo-night/walker.css
@@ -1,0 +1,4 @@
+@define-color base #1a1b26;
+@define-color text #cfc9c2;
+@define-color border #cfc9c2;
+@define-color selected-text #7dcfff;

--- a/themes/vancouver/walker.css
+++ b/themes/vancouver/walker.css
@@ -1,0 +1,4 @@
+@define-color base #2a2a2a;
+@define-color text #f0f0f0;
+@define-color border #f0f0f0;
+@define-color selected-text #a2d9ce;


### PR DESCRIPTION
This commit updates the walker configuration to support version 1.0+.

- The `walker` command in `hypr-menu` is updated to use the `--dmenu` flag instead of `-dmenu`.
- The theming for `walker` is now integrated with the existing theming system. A `walker.css` file has been added to each theme directory, and the `hypr-theme-set` script has been updated to create a symbolic link to the correct theme file when the theme is changed.
- The walker configuration has been updated to use the `current` theme, which points to the symlinked theme file.