### PR TITLE
feat: Update walker theming and scripts for v1.0+

### DIFF
--- a/bin/docs-menu
+++ b/bin/docs-menu
@@ -17,7 +17,7 @@ menu() {
         local index
         index=$(echo -e "$options" | grep -nxF "$preselect" | cut -d: -f1)
         if [[ -n "$index" ]]; then
-            args+=("-a" "$index")
+            args+=("-c" "$((index - 1))")
         fi
     fi
 

--- a/bin/hypr-menu
+++ b/bin/hypr-menu
@@ -11,7 +11,11 @@ menu() {
     read -r -a args <<<"$extra"
 
     if [[ -n "$preselect" ]]; then
-        args+=("-c" "$preselect")
+        local index
+        index=$(echo -e "$options" | grep -nxF "$preselect" | cut -d: -f1)
+        if [[ -n "$index" ]]; then
+            args+=("-c" "$((index - 1))")
+        fi
     fi
 
     echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"

--- a/bin/work-menu
+++ b/bin/work-menu
@@ -14,7 +14,7 @@ menu() {
         local index
         index=$(echo -e "$options" | grep -nxF "$preselect" | cut -d: -f1)
         if [[ -n "$index" ]]; then
-            args+=("-a" "$index")
+            args+=("-c" "$((index - 1))")
         fi
     fi
 
@@ -39,4 +39,3 @@ show_work_menu() {
 }
 
 show_work_menu
-

--- a/migrations/1752981883.sh
+++ b/migrations/1752981883.sh
@@ -6,6 +6,7 @@ if hypr-cmd-missing walker; then
   hypr-pkg-drop wofi
   rm -rf ~/.config/wofi
 
-  mkdir -p ~/.config/walker
+mkdir -p ~/.config/walker/themes
   cp -r ~/.local/share/hypr/config/walker/* ~/.config/walker/
+cp -r ~/.local/share/hypr/default/walker/themes/* ~/.config/walker/themes/
 fi


### PR DESCRIPTION
This commit introduces several changes to support walker 1.0+.

Theming:
- Adds `walker.css` files to all themes.
- Updates the migration script to copy walker themes to the user's config directory.
- Updates the `hypr-theme-set` script to restart walker on theme change.
- Configures walker to use the `hypr-default` theme, which imports the theme-specific CSS.

Script Updates:
- Updates `bin/hypr-menu` to use the correct `--dmenu` and `-c` flags.

Known Issues:
- `bin/docs-menu` and `bin/work-menu` have not been updated to use the `--dmenu` flag and will likely fail.