### PR TITLE
fix(themes): correct walker and hypr theme colors

### DIFF
--- a/themes/adwaita-dark/hyprland.conf
+++ b/themes/adwaita-dark/hyprland.conf
@@ -1,3 +1,4 @@
 general {
     col.active_border = rgb(78aeed)
+    col.inactive_border = rgb(555555)
 }

--- a/themes/amateur/hyprland.conf
+++ b/themes/amateur/hyprland.conf
@@ -1,5 +1,5 @@
 general {
-    col.active_border = rgba(00eacbff) rgba(00b362ff) 45deg
-    col.inactive_border = rgba(2d3748ff)
+    col.active_border = rgb(63B3ED)
+    col.inactive_border = rgb(4A5568)
     col.nogroup_border = rgba(1a202cff)
 }

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1A202C;
 @define-color text #E2E8F0;
 @define-color border #E2E8F0;
-@define-color selected-text #00eacb;
+@define-color selected-text #63B3ED;

--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -1,4 +1,5 @@
 general {
-    col.active_border = rgb(1e66f5)
+    col.active_border = rgb(4c4f69)
+    col.inactive_border = rgb(acb0be)
 }
 

--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,3 +1,4 @@
 general {
-    col.active_border = rgb(c6d0f5)
+    col.active_border = rgb(cad3f5)
+    col.inactive_border = rgb(5b6078)
 }

--- a/themes/catppuccin/walker.css
+++ b/themes/catppuccin/walker.css
@@ -1,4 +1,4 @@
 @define-color base #24273a;
-@define-color text #c6d0f5;
-@define-color border #c6d0f5;
-@define-color selected-text #8caaee;
+@define-color text #cad3f5;
+@define-color border #cad3f5;
+@define-color selected-text #8aadf4;

--- a/themes/everforest/hyprland.conf
+++ b/themes/everforest/hyprland.conf
@@ -1,3 +1,4 @@
 general {
     col.active_border = rgb(d3c6aa)
+    col.inactive_border = rgb(374145)
 }

--- a/themes/everforest/walker.css
+++ b/themes/everforest/walker.css
@@ -1,4 +1,4 @@
-@define-color base #2d353b;
+@define-color base #272E33;
 @define-color text #d3c6aa;
 @define-color border #d3c6aa;
 @define-color selected-text #dbbc7f;

--- a/themes/gruvbox/hyprland.conf
+++ b/themes/gruvbox/hyprland.conf
@@ -1,3 +1,4 @@
 general {
-    col.active_border = rgb(a89984)
+    col.active_border = rgb(ebdbb2)
+    col.inactive_border = rgb(3c3836)
 }

--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -1,5 +1,6 @@
 general {
     col.active_border = rgb(dcd7ba)
+    col.inactive_border = rgb(54546D)
 }
 
 # Kanagawa backdrop is too strong for detault opacity

--- a/themes/kanagawa/walker.css
+++ b/themes/kanagawa/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1f1f28;
 @define-color text #dcd7ba;
 @define-color border #dcd7ba;
-@define-color selected-text #dca561;
+@define-color selected-text #E6C384;

--- a/themes/matte-black/hyprland.conf
+++ b/themes/matte-black/hyprland.conf
@@ -1,3 +1,4 @@
 general {
-    col.active_border = rgb(8A8A8D)
+    col.active_border = rgb(B91C1C)
+    col.inactive_border = rgb(333333)
 }


### PR DESCRIPTION
This commit corrects the color palettes for all walker and hypr themes. It ensures that all themes have consistent border colors defined in their hyprland.conf files and that the colors in the walker.css files match the overall theme palette.