### PR TITLE
fix(hypr-menu): remove invalid -w option from walker

### DIFF
--- a/bin/hypr-menu
+++ b/bin/hypr-menu
@@ -112,7 +112,7 @@ show_theme_menu() {
 }
 
 show_font_menu() {
-    theme=$(menu "Font" "$(hypr-font-list)" "-w 350" "$(hypr-font-current)")
+    theme=$(menu "Font" "$(hypr-font-list)" "" "$(hypr-font-current)")
     if [[ "$theme" == "CNCLD" || -z "$theme" ]]; then
         show_main_menu
     else
@@ -283,7 +283,7 @@ show_install_style_menu() {
 }
 
 show_install_font_menu() {
-    case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono" "-w 350") in
+    case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono") in
     *Meslo*) install_font "Meslo LG Mono" "ttf-meslo-nerd" "MesloLGL Nerd Font" ;;
     *Fira*) install_font "Fira Code" "ttf-firacode-nerd" "FiraCode Nerd Font" ;;
     *Victor*) install_font "Victor Code" "ttf-victor-mono-nerd" "VictorMono Nerd Font" ;;


### PR DESCRIPTION
This commit removes the `-w` option that was being passed to the `walker` command in the `hypr-menu` script. This option is no longer supported by `walker` and was causing an error when trying to change fonts from the style menu.