### PR TITLE
fix(themes): correct all walker and hypr theme colors

### DIFF
--- a/bin/hypr-menu
+++ b/bin/hypr-menu
@@ -112,7 +112,7 @@ show_theme_menu() {
 }
 
 show_font_menu() {
-    theme=$(menu "Font" "$(hypr-font-list)" "" "$(hypr-font-current)")
+    theme=$(menu "Font" "$(hypr-font-list)" "-w 350" "$(hypr-font-current)")
     if [[ "$theme" == "CNCLD" || -z "$theme" ]]; then
         show_main_menu
     else
@@ -283,7 +283,7 @@ show_install_style_menu() {
 }
 
 show_install_font_menu() {
-    case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono") in
+    case $(menu "Install" "  Meslo LG Mono\n  Fira Code\n  Victor Code\n  Bistream Vera Mono" "-w 350") in
     *Meslo*) install_font "Meslo LG Mono" "ttf-meslo-nerd" "MesloLGL Nerd Font" ;;
     *Fira*) install_font "Fira Code" "ttf-firacode-nerd" "FiraCode Nerd Font" ;;
     *Victor*) install_font "Victor Code" "ttf-victor-mono-nerd" "VictorMono Nerd Font" ;;

--- a/themes/nord/hyprland.conf
+++ b/themes/nord/hyprland.conf
@@ -1,3 +1,4 @@
 general {
-    col.active_border = rgb(D8DEE9)
+    col.active_border = rgb(eceff4)
+    col.inactive_border = rgb(4c566a)
 }

--- a/themes/nord/walker.css
+++ b/themes/nord/walker.css
@@ -1,4 +1,4 @@
 @define-color base #2E3440;
-@define-color text #D8DEE9;
-@define-color border #D8DEE9;
+@define-color text #eceff4;
+@define-color border #eceff4;
 @define-color selected-text #88C0D0;

--- a/themes/osaka-jade/hyprland.conf
+++ b/themes/osaka-jade/hyprland.conf
@@ -1,4 +1,5 @@
 # focus window color (border)
 general {
     col.active_border = rgb(71CEAD)
+    col.inactive_border = rgb(333333)
 }

--- a/themes/ristretto/hyprland.conf
+++ b/themes/ristretto/hyprland.conf
@@ -1,4 +1,5 @@
 general {
     # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
     col.active_border = rgb(e6d9db)
+    col.inactive_border = rgb(4c3f3f)
 }

--- a/themes/rose-pine/hyprland.conf
+++ b/themes/rose-pine/hyprland.conf
@@ -1,3 +1,4 @@
 general {
     col.active_border = rgb(575279)
+    col.inactive_border = rgb(f2e9e1)
 }

--- a/themes/rose-pine/walker.css
+++ b/themes/rose-pine/walker.css
@@ -1,4 +1,4 @@
 @define-color base #faf4ed;
 @define-color text #575279;
 @define-color border #575279;
-@define-color selected-text #88C0D0;
+@define-color selected-text #ea9d34;

--- a/themes/tokyo-night/hyprland.conf
+++ b/themes/tokyo-night/hyprland.conf
@@ -1,4 +1,5 @@
 general {
-    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.active_border = rgb(a9b1d6)
+    col.inactive_border = rgb(414868)
 }
 

--- a/themes/tokyo-night/walker.css
+++ b/themes/tokyo-night/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1a1b26;
-@define-color text #cfc9c2;
-@define-color border #cfc9c2;
-@define-color selected-text #7dcfff;
+@define-color text #a9b1d6;
+@define-color border #a9b1d6;
+@define-color selected-text #7aa2f7;

--- a/themes/vancouver/walker.css
+++ b/themes/vancouver/walker.css
@@ -1,4 +1,4 @@
 @define-color base #2a2a2a;
 @define-color text #f0f0f0;
 @define-color border #f0f0f0;
-@define-color selected-text #a2d9ce;
+@define-color selected-text #f9e79f;


### PR DESCRIPTION
This commit corrects the color palettes for all walker and hypr themes. It ensures that all themes have consistent border colors defined in their hyprland.conf files and that the colors in the walker.css files match the overall theme palette.

This addresses the issue where some themes were missing border colors and had inconsistent color palettes.