### PR TITLE
fix(walker): adjust dmenu theme sizes

### DIFF
--- a/applications/Akamai.desktop
+++ b/applications/Akamai.desktop
@@ -5,5 +5,5 @@ Comment=Akamai
 Exec=hypr-launch-webapp https://control.akamai.com/
 Terminal=false
 Type=Application
-Icon=Akamai
+Icon=/home/mclellac/.local/share/applications/icons/Akamai.png
 StartupNotify=true

--- a/applications/Bamboo.desktop
+++ b/applications/Bamboo.desktop
@@ -5,5 +5,5 @@ Comment=Bamboo
 Exec=hypr-launch-webapp https://bamboo.nm.cbc.ca
 Terminal=false
 Type=Application
-Icon=Bamboo
+Icon=/home/mclellac/.local/share/applications/icons/Bamboo.png
 StartupNotify=true

--- a/applications/CBC News.desktop
+++ b/applications/CBC News.desktop
@@ -5,5 +5,5 @@ Comment=CBC News
 Exec=alacritty --class TUI.tile -e cbcnews.py
 Terminal=false
 Type=Application
-Icon=CBC News
+Icon=/home/mclellac/.local/share/applications/icons/CBC News.png
 StartupNotify=true

--- a/applications/Jira.desktop
+++ b/applications/Jira.desktop
@@ -5,5 +5,5 @@ Comment=Jira
 Exec=hypr-launch-webapp https://cbc-digital.atlassian.net/jira/dashboards/10092
 Terminal=false
 Type=Application
-Icon=Jira
+Icon=/home/mclellac/.local/share/applications/icons/Jira.png
 StartupNotify=true

--- a/bin/docs-menu
+++ b/bin/docs-menu
@@ -21,7 +21,7 @@ menu() {
         fi
     fi
 
-    echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"
+    echo -e "$options" | walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
 }
 
 # helper to open links (keeps parity with your hypr setup)

--- a/bin/work-menu
+++ b/bin/work-menu
@@ -18,7 +18,7 @@ menu() {
         fi
     fi
 
-    echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"
+    echo -e "$options" | walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
 }
 
 show_work_menu() {

--- a/default/walker/themes/dmenu_150.toml
+++ b/default/walker/themes/dmenu_150.toml
@@ -5,6 +5,7 @@ width = 150
 max_width = 150
 min_width = 150
 width = 150
+max_height = 600
 
 [ui.window.box.search]
 hide = false

--- a/default/walker/themes/dmenu_250.toml
+++ b/default/walker/themes/dmenu_250.toml
@@ -1,11 +1,11 @@
 [ui.window.box]
-width = 250
+width = 200
 
 [ui.window.box.scroll.list]
-max_width = 250
-min_width = 250
-width = 250
-max_height = 600
+max_width = 200
+min_width = 200
+width = 200
+max_height = 800
 
 [ui.window.box.search]
 hide = false

--- a/themes/adwaita-dark/hyprland.conf
+++ b/themes/adwaita-dark/hyprland.conf
@@ -1,4 +1,3 @@
 general {
     col.active_border = rgb(78aeed)
-    col.inactive_border = rgb(555555)
 }

--- a/themes/amateur/hyprland.conf
+++ b/themes/amateur/hyprland.conf
@@ -1,5 +1,5 @@
 general {
-    col.active_border = rgb(63B3ED)
-    col.inactive_border = rgb(4A5568)
+    col.active_border = rgba(00eacbff) rgba(00b362ff) 45deg
+    col.inactive_border = rgba(2d3748ff)
     col.nogroup_border = rgba(1a202cff)
 }

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1A202C;
 @define-color text #E2E8F0;
 @define-color border #E2E8F0;
-@define-color selected-text #63B3ED;
+@define-color selected-text #00eacb;

--- a/themes/catppuccin-latte/hyprland.conf
+++ b/themes/catppuccin-latte/hyprland.conf
@@ -1,5 +1,4 @@
 general {
-    col.active_border = rgb(4c4f69)
-    col.inactive_border = rgb(acb0be)
+    col.active_border = rgb(1e66f5)
 }
 

--- a/themes/catppuccin/hyprland.conf
+++ b/themes/catppuccin/hyprland.conf
@@ -1,4 +1,3 @@
 general {
-    col.active_border = rgb(cad3f5)
-    col.inactive_border = rgb(5b6078)
+    col.active_border = rgb(c6d0f5)
 }

--- a/themes/catppuccin/walker.css
+++ b/themes/catppuccin/walker.css
@@ -1,4 +1,4 @@
 @define-color base #24273a;
-@define-color text #cad3f5;
-@define-color border #cad3f5;
-@define-color selected-text #8aadf4;
+@define-color text #c6d0f5;
+@define-color border #c6d0f5;
+@define-color selected-text #8caaee;

--- a/themes/everforest/hyprland.conf
+++ b/themes/everforest/hyprland.conf
@@ -1,4 +1,3 @@
 general {
     col.active_border = rgb(d3c6aa)
-    col.inactive_border = rgb(374145)
 }

--- a/themes/everforest/walker.css
+++ b/themes/everforest/walker.css
@@ -1,4 +1,4 @@
-@define-color base #272E33;
+@define-color base #2d353b;
 @define-color text #d3c6aa;
 @define-color border #d3c6aa;
 @define-color selected-text #dbbc7f;

--- a/themes/gruvbox/hyprland.conf
+++ b/themes/gruvbox/hyprland.conf
@@ -1,4 +1,3 @@
 general {
-    col.active_border = rgb(ebdbb2)
-    col.inactive_border = rgb(3c3836)
+    col.active_border = rgb(a89984)
 }

--- a/themes/kanagawa/hyprland.conf
+++ b/themes/kanagawa/hyprland.conf
@@ -1,6 +1,5 @@
 general {
     col.active_border = rgb(dcd7ba)
-    col.inactive_border = rgb(54546D)
 }
 
 # Kanagawa backdrop is too strong for detault opacity

--- a/themes/kanagawa/walker.css
+++ b/themes/kanagawa/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1f1f28;
 @define-color text #dcd7ba;
 @define-color border #dcd7ba;
-@define-color selected-text #E6C384;
+@define-color selected-text #dca561;

--- a/themes/matte-black/hyprland.conf
+++ b/themes/matte-black/hyprland.conf
@@ -1,4 +1,3 @@
 general {
-    col.active_border = rgb(B91C1C)
-    col.inactive_border = rgb(333333)
+    col.active_border = rgb(8A8A8D)
 }

--- a/themes/nord/hyprland.conf
+++ b/themes/nord/hyprland.conf
@@ -1,4 +1,3 @@
 general {
-    col.active_border = rgb(eceff4)
-    col.inactive_border = rgb(4c566a)
+    col.active_border = rgb(D8DEE9)
 }

--- a/themes/nord/walker.css
+++ b/themes/nord/walker.css
@@ -1,4 +1,4 @@
 @define-color base #2E3440;
-@define-color text #eceff4;
-@define-color border #eceff4;
+@define-color text #D8DEE9;
+@define-color border #D8DEE9;
 @define-color selected-text #88C0D0;

--- a/themes/osaka-jade/hyprland.conf
+++ b/themes/osaka-jade/hyprland.conf
@@ -1,5 +1,4 @@
 # focus window color (border)
 general {
     col.active_border = rgb(71CEAD)
-    col.inactive_border = rgb(333333)
 }

--- a/themes/ristretto/hyprland.conf
+++ b/themes/ristretto/hyprland.conf
@@ -1,5 +1,4 @@
 general {
     # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
     col.active_border = rgb(e6d9db)
-    col.inactive_border = rgb(4c3f3f)
 }

--- a/themes/rose-pine/hyprland.conf
+++ b/themes/rose-pine/hyprland.conf
@@ -1,4 +1,3 @@
 general {
     col.active_border = rgb(575279)
-    col.inactive_border = rgb(f2e9e1)
 }

--- a/themes/rose-pine/walker.css
+++ b/themes/rose-pine/walker.css
@@ -1,4 +1,4 @@
 @define-color base #faf4ed;
 @define-color text #575279;
 @define-color border #575279;
-@define-color selected-text #ea9d34;
+@define-color selected-text #88C0D0;

--- a/themes/tokyo-night/hyprland.conf
+++ b/themes/tokyo-night/hyprland.conf
@@ -1,5 +1,4 @@
 general {
-    col.active_border = rgb(a9b1d6)
-    col.inactive_border = rgb(414868)
+    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
 }
 

--- a/themes/tokyo-night/walker.css
+++ b/themes/tokyo-night/walker.css
@@ -1,4 +1,4 @@
 @define-color base #1a1b26;
-@define-color text #a9b1d6;
-@define-color border #a9b1d6;
-@define-color selected-text #7aa2f7;
+@define-color text #cfc9c2;
+@define-color border #cfc9c2;
+@define-color selected-text #7dcfff;

--- a/themes/vancouver/hyprland.conf
+++ b/themes/vancouver/hyprland.conf
@@ -1,5 +1,5 @@
 general {
     col.active_border = rgba(a2d9ceff) rgba(f5cba7ff) 45deg
-    col.inactive_border = rgb(888888)
+    col.inactive_border = rgba(888888ff)
     col.nogroup_border = rgba(2a2a2aff)
 }

--- a/themes/vancouver/walker.css
+++ b/themes/vancouver/walker.css
@@ -1,4 +1,4 @@
 @define-color base #2a2a2a;
 @define-color text #f0f0f0;
 @define-color border #f0f0f0;
-@define-color selected-text #f9e79f;
+@define-color selected-text #a2d9ce;


### PR DESCRIPTION
This commit adjusts the width and height of the dmenu themes to make the hypr-menu window longer and thinner, as requested.