### PR TITLE
Fix(walker): Remove hardcoded theme from menu scripts

### DIFF
--- a/bin/docs-menu
+++ b/bin/docs-menu
@@ -21,7 +21,7 @@ menu() {
         fi
     fi
 
-    echo -e "$options" | walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
+    echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"
 }
 
 # helper to open links (keeps parity with your hypr setup)

--- a/bin/work-menu
+++ b/bin/work-menu
@@ -18,7 +18,7 @@ menu() {
         fi
     fi
 
-    echo -e "$options" | walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
+    echo -e "$options" | walker --dmenu -p "$prompt…" "${args[@]}"
 }
 
 show_work_menu() {


### PR DESCRIPTION
The `docs-menu` and `work-menu` scripts were previously overriding the user's walker theme by explicitly setting it to `dmenu_250`.

This change removes the hardcoded `--theme` argument from the `walker` command in both scripts, allowing them to use the theme defined in the main `walker` configuration file. This respects the user's theme settings and ensures a consistent look and feel across all `walker` instances.