### PR TITLE
feat: Add consistent box-wrapper styles to all themes

### DIFF
--- a/default/walker/themes/hypr-default/style.css
+++ b/default/walker/themes/hypr-default/style.css
@@ -21,10 +21,13 @@ scrollbar {
 }
 
 .box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
   background: @window_bg_color;
   padding: 20px;
-  border: 2px solid @border;
-  border-radius: 0px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
 }
 
 .preview-box,

--- a/themes/adwaita-dark/walker.css
+++ b/themes/adwaita-dark/walker.css
@@ -2,3 +2,13 @@
 @define-color text #ffffff;
 @define-color border #ffffff;
 @define-color selected-text #78aeed;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/amateur/walker.css
+++ b/themes/amateur/walker.css
@@ -2,3 +2,13 @@
 @define-color text #E2E8F0;
 @define-color border #E2E8F0;
 @define-color selected-text #00eacb;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/catppuccin-latte/walker.css
+++ b/themes/catppuccin-latte/walker.css
@@ -2,3 +2,13 @@
 @define-color text #4c4f69;
 @define-color border #4c4f69;
 @define-color selected-text #1e66f5;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/catppuccin/walker.css
+++ b/themes/catppuccin/walker.css
@@ -2,3 +2,13 @@
 @define-color text #c6d0f5;
 @define-color border #c6d0f5;
 @define-color selected-text #8caaee;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/everforest/walker.css
+++ b/themes/everforest/walker.css
@@ -2,3 +2,13 @@
 @define-color text #d3c6aa;
 @define-color border #d3c6aa;
 @define-color selected-text #dbbc7f;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/gruvbox/walker.css
+++ b/themes/gruvbox/walker.css
@@ -2,3 +2,13 @@
 @define-color text #ebdbb2;
 @define-color border #ebdbb2;
 @define-color selected-text #fabd2f;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/kanagawa/walker.css
+++ b/themes/kanagawa/walker.css
@@ -2,3 +2,13 @@
 @define-color text #dcd7ba;
 @define-color border #dcd7ba;
 @define-color selected-text #dca561;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/matte-black/walker.css
+++ b/themes/matte-black/walker.css
@@ -2,3 +2,13 @@
 @define-color text #EAEAEA;
 @define-color border #EAEAEA;
 @define-color selected-text #B91C1C;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/nord/walker.css
+++ b/themes/nord/walker.css
@@ -2,3 +2,13 @@
 @define-color text #D8DEE9;
 @define-color border #D8DEE9;
 @define-color selected-text #88C0D0;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/osaka-jade/walker.css
+++ b/themes/osaka-jade/walker.css
@@ -2,3 +2,13 @@
 @define-color text #ebfff2;
 @define-color border #ebfff2;
 @define-color selected-text #e1b55e;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/ristretto/walker.css
+++ b/themes/ristretto/walker.css
@@ -2,3 +2,13 @@
 @define-color text #e6d9db;
 @define-color border #e6d9db;
 @define-color selected-text #fabd2f;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/rose-pine/walker.css
+++ b/themes/rose-pine/walker.css
@@ -2,3 +2,13 @@
 @define-color text #575279;
 @define-color border #575279;
 @define-color selected-text #88C0D0;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/tokyo-night/walker.css
+++ b/themes/tokyo-night/walker.css
@@ -2,3 +2,13 @@
 @define-color text #cfc9c2;
 @define-color border #cfc9c2;
 @define-color selected-text #7dcfff;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}

--- a/themes/vancouver/walker.css
+++ b/themes/vancouver/walker.css
@@ -2,3 +2,13 @@
 @define-color text #f0f0f0;
 @define-color border #f0f0f0;
 @define-color selected-text #a2d9ce;
+
+.box-wrapper {
+  box-shadow:
+    0 19px 38px rgba(0, 0, 0, 0.3),
+    0 15px 12px rgba(0, 0, 0, 0.22);
+  background: @window_bg_color;
+  padding: 20px;
+  border-radius: 10px;
+  border: 3px solid darker(@accent_bg_color);
+}


### PR DESCRIPTION
This change adds the .box-wrapper CSS rule to all walker.css files in the themes directory that were missing it. It also updates the default style in `default/walker/themes/hypr-default/style.css` to match, ensuring a consistent look and feel across all themes.