### PR TITLE
fix(hyprland): make webapps opaque

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -7,6 +7,7 @@ windowrule = tile, tag:chromium-based-browser
 
 # Only a subtle opacity change, but not for video sites
 windowrule = opacity 1 1, tag:chromium-based-browser
+windowrule = opacity 1 1, class:^(crx_.*)$
 windowrule = opacity 1 1, tag:firefox-based-browser
 
 # Some video sites should never have opacity applied to them


### PR DESCRIPTION
Webapps launched via the --app flag in chrome-based browsers were appearing transparent due to a global opacity setting. This change adds a specific windowrule to make these windows fully opaque, matching the behavior of regular browser windows.

The new rule targets windows with a class name starting with `crx_`, which is typical for chrome web apps.