### PR TITLE
The user was experiencing freezing when copying and pasting text. Thi…

### DIFF
--- a/config/hypr/autostart.conf
+++ b/config/hypr/autostart.conf
@@ -3,4 +3,5 @@
 ####
 exec-once = elephant
 exec-once = walker --gapplication-service
+exec-once = wl-clip-persist --clipboard regular --all-mime-type-regex '^(?!x-kde-passwordManagerHint).+'
 exec-once = pkill fcitx5


### PR DESCRIPTION
…s was likely due to the absence of a clipboard persistence tool.

This change adds `wl-clip-persist` to the Hyprland autostart configuration to ensure that clipboard history is maintained across application sessions. This should stabilize the `elephant` clipboard manager and prevent the freezing issue.