### PR TITLE
fix(hyprland): correct regex for pip window rules

### DIFF
--- a/default/hypr/apps/pip.conf
+++ b/default/hypr/apps/pip.conf
@@ -2,8 +2,8 @@
 # As a result, we must separate static rules from dynamic rules.
 #
 # Static rules are applied to the window on creation, and then the "+pip" tag is added.
-windowrule = float, pin, size 600 338, move 100%-w-40 4%, title:(Picture.{0,1}in.{0,1}[Pp]icture)
-windowrule = tag +pip, title:(Picture.{0,1}in.{0,1}[Pp]icture)
+windowrule = float, pin, size 600 338, move 100%-w-40 4%, title:(Picture.?in.?[Pp]icture)
+windowrule = tag +pip, title:(Picture.?in.?[Pp]icture)
 
 # Dynamic rules are applied to any window with the "pip" tag.
 windowrule = keepaspectratio, noborder, opacity 1 1, tag:pip


### PR DESCRIPTION
The window rule for picture-in-picture was using a `{0,1}` quantifier in its regular expression, which is not supported by Hyprland's configuration parser and was causing errors.

This commit replaces the invalid quantifier with `?` to ensure the regex is parsed correctly.

This resolves the `hyprctl configerrors` output reported by the user and makes the picture-in-picture functionality work as expected with recent versions of Hyprland.