### PR TITLE
feat: Add kitty terminal theming support

### DIFF
--- a/bin/hypr-theme-set
+++ b/bin/hypr-theme-set
@@ -95,6 +95,11 @@ fi
 # Trigger alacritty config reload
 touch "$HOME/.config/alacritty/alacritty.toml"
 
+# Reload kitty config
+if pgrep -x kitty >/dev/null; then
+  kitty @ set-colors --all --configured "$CURRENT_THEME_DIR/kitty.conf"
+fi
+
 # Restart components to apply new theme
 pkill -SIGUSR2 btop
 hypr-restart-waybar

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -1,0 +1,46 @@
+# Transparency
+background_opacity 0.8
+
+# Cursor
+cursor_shape beam
+cursor_trail 1
+
+# Padding (why weird value? consistency with foot)
+window_margin_width 21.75
+
+# No stupid close confirmation
+confirm_os_window_close 0
+
+# Copy
+map ctrl+c      copy_or_interrupt
+
+# Search
+map ctrl+f      launch --location=hsplit --allow-remote-control kitty +kitten search.py @active-kitty-window-id
+map kitty_mod+f launch --location=hsplit --allow-remote-control kitty +kitten search.py @active-kitty-window-id
+
+# Scroll & Zoom
+map page_up             scroll_page_up
+map page_down           scroll_page_down
+
+map ctrl+plus           change_font_size all +1
+map ctrl+equal          change_font_size all +1
+map ctrl+kp_add         change_font_size all +1
+map ctrl+minus          change_font_size all -1
+map ctrl+underscore     change_font_size all -1
+map ctrl+kp_subtract    change_font_size all -1
+map ctrl+0              change_font_size all 0
+map ctrl+kp_0           change_font_size all 0
+
+# Allow remote control so that the theme can be changed on the fly
+allow_remote_control yes
+
+# Include the theme file
+include ./theme.conf
+
+# BEGIN_KITTY_FONTS
+font_family      family="JetBrainsMonoNL Nerd Font Mono"
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+# END_KITTY_FONTS
+font_size 14.0

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -31,3 +31,6 @@ ln -snf ~/.config/hypr/current/theme/btop.theme ~/.config/btop/themes/current.th
 
 mkdir -p ~/.config/mako
 ln -snf ~/.config/hypr/current/theme/mako.ini ~/.config/mako/config
+
+mkdir -p ~/.config/kitty
+ln -snf ~/.config/hypr/current/theme/kitty.conf ~/.config/kitty/theme.conf

--- a/themes/adwaita-dark/kitty.conf
+++ b/themes/adwaita-dark/kitty.conf
@@ -1,0 +1,45 @@
+# Adwaita Dark color scheme for kitty terminal emulator
+# Based on https://gitlab.com/jessieh/adwaita-dark-theme
+
+foreground #deddda
+background #1c1c1c
+
+selection_foreground #deddda
+selection_background #454545
+
+url_color #64a6f4
+
+cursor #deddda
+cursor_text_color #1c1c1c
+
+# Black
+color0 #464646
+color8 #9a9996
+
+# Red
+color1 #ed333b
+color9 #f66151
+
+# Green
+color2 #57e389
+color10 #8ff0a4
+
+# Yellow
+color3 #ff7800
+color11 #ffa348
+
+# Blue
+color4 #62a0ea
+color12 #99c1f1
+
+# Magenta
+color5 #9141ac
+color13 #dc8add
+
+# Cyan
+color6 #5bc8af
+color14 #93ddc2
+
+# White
+color7 #deddda
+color15 #f6f5f4

--- a/themes/amateur/kitty.conf
+++ b/themes/amateur/kitty.conf
@@ -1,0 +1,45 @@
+# Amateur color scheme for kitty terminal emulator
+# Based on the colors defined in amateur.lua
+
+foreground #E2E8F0
+background #1A202C
+
+selection_foreground #1A202C
+selection_background #E2E8F0
+
+url_color #63B3ED
+
+cursor #E2E8F0
+cursor_text_color #1A202C
+
+# Black
+color0 #4A5568
+color8 #6A7588
+
+# Red
+color1 #F56565
+color9 #FF8585
+
+# Green
+color2 #48BB78
+color10 #68DB98
+
+# Yellow
+color3 #F6AD55
+color11 #FFCD75
+
+# Blue
+color4 #63B3ED
+color12 #83D3FF
+
+# Magenta
+color5 #4FD1C5
+color13 #6FE1E5
+
+# Cyan
+color6 #4FD1C5
+color14 #6FE1E5
+
+# White
+color7 #F7FAFC
+color15 #F7FAFC

--- a/themes/catppuccin-latte/kitty.conf
+++ b/themes/catppuccin-latte/kitty.conf
@@ -1,0 +1,80 @@
+# vim:ft=kitty
+
+## name:     Catppuccin Kitty Latte
+## author:   Catppuccin Org
+## license:  MIT
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/latte.conf
+## blurb:    Soothing pastel theme for the high-spirited!
+
+
+
+# The basic colors
+foreground              #4c4f69
+background              #eff1f5
+selection_foreground    #eff1f5
+selection_background    #dc8a78
+
+# Cursor colors
+cursor                  #dc8a78
+cursor_text_color       #eff1f5
+
+# URL underline color when hovering with mouse
+url_color               #dc8a78
+
+# Kitty window border colors
+active_border_color     #7287fd
+inactive_border_color   #9ca0b0
+bell_border_color       #df8e1d
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #eff1f5
+active_tab_background   #8839ef
+inactive_tab_foreground #4c4f69
+inactive_tab_background #9ca0b0
+tab_bar_background      #bcc0cc
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #eff1f5
+mark1_background #7287fd
+mark2_foreground #eff1f5
+mark2_background #8839ef
+mark3_foreground #eff1f5
+mark3_background #209fb5
+
+# The 16 terminal colors
+
+# black
+color0 #5c5f77
+color8 #6c6f85
+
+# red
+color1 #d20f39
+color9 #d20f39
+
+# green
+color2  #40a02b
+color10 #40a02b
+
+# yellow
+color3  #df8e1d
+color11 #df8e1d
+
+# blue
+color4  #1e66f5
+color12 #1e66f5
+
+# magenta
+color5  #ea76cb
+color13 #ea76cb
+
+# cyan
+color6  #179299
+color14 #179299
+
+# white
+color7  #acb0be
+color15 #bcc0cc

--- a/themes/catppuccin/kitty.conf
+++ b/themes/catppuccin/kitty.conf
@@ -1,0 +1,80 @@
+# vim:ft=kitty
+
+## name:     Catppuccin Kitty Mocha
+## author:   Catppuccin Org
+## license:  MIT
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/mocha.conf
+## blurb:    Soothing pastel theme for the high-spirited!
+
+
+
+# The basic colors
+foreground              #cdd6f4
+background              #1e1e2e
+selection_foreground    #1e1e2e
+selection_background    #f5e0dc
+
+# Cursor colors
+cursor                  #f5e0dc
+cursor_text_color       #1e1e2e
+
+# URL underline color when hovering with mouse
+url_color               #f5e0dc
+
+# Kitty window border colors
+active_border_color     #b4befe
+inactive_border_color   #6c7086
+bell_border_color       #f9e2af
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #11111b
+active_tab_background   #cba6f7
+inactive_tab_foreground #cdd6f4
+inactive_tab_background #181825
+tab_bar_background      #11111b
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #1e1e2e
+mark1_background #b4befe
+mark2_foreground #1e1e2e
+mark2_background #cba6f7
+mark3_foreground #1e1e2e
+mark3_background #74c7ec
+
+# The 16 terminal colors
+
+# black
+color0 #45475a
+color8 #585b70
+
+# red
+color1 #f38ba8
+color9 #f38ba8
+
+# green
+color2  #a6e3a1
+color10 #a6e3a1
+
+# yellow
+color3  #f9e2af
+color11 #f9e2af
+
+# blue
+color4  #89b4fa
+color12 #89b4fa
+
+# magenta
+color5  #f5c2e7
+color13 #f5c2e7
+
+# cyan
+color6  #94e2d5
+color14 #94e2d5
+
+# white
+color7  #bac2de
+color15 #a6adc8

--- a/themes/everforest/kitty.conf
+++ b/themes/everforest/kitty.conf
@@ -1,0 +1,48 @@
+# A port of forest night by sainnhe
+# https://github.com/sainnhe/forest-night
+
+background  #323d43
+foreground  #d8caac
+
+cursor                #d8caac
+
+selection_foreground  #d8caac
+selection_background  #505a60
+
+color0  #3c474d
+color8  #868d80
+
+# red
+color1                #e68183
+# light red
+color9                #e68183
+
+# green
+color2                #a7c080
+# light green
+color10               #a7c080
+
+# yellow
+color3                #d9bb80
+# light yellow
+color11               #d9bb80
+
+# blue
+color4                #83b6af
+# light blue
+color12               #83b6af
+
+# magenta
+color5                #d39bb6
+# light magenta
+color13               #d39bb6
+
+# cyan
+color6                #87c095
+# light cyan
+color14               #87c095
+
+# light gray
+color7                #868d80
+# dark gray
+color15               #868d80

--- a/themes/gruvbox/kitty.conf
+++ b/themes/gruvbox/kitty.conf
@@ -1,0 +1,40 @@
+# gruvbox-dark colorscheme for kitty
+# snazzy theme used as base
+
+foreground            #ebdbb2
+background            #272727
+selection_foreground  #655b53
+selection_background  #ebdbb2
+url_color             #d65c0d
+
+# black
+color0   #272727
+color8   #928373
+
+# red
+color1   #cc231c
+color9   #fb4833
+
+# green
+color2   #989719
+color10  #b8ba25
+
+# yellow
+color3   #d79920
+color11  #fabc2e
+
+# blue
+color4  #448488
+color12 #83a597
+
+# magenta
+color5   #b16185
+color13  #d3859a
+
+# cyan
+color6   #689d69
+color14  #8ec07b
+
+# white
+color7   #a89983
+color15  #ebdbb2

--- a/themes/kanagawa/kitty.conf
+++ b/themes/kanagawa/kitty.conf
@@ -1,0 +1,45 @@
+# Kanagawa color scheme for kitty terminal emulator
+# Based on the colors defined in alacritty.toml
+
+foreground #dcd7ba
+background #1f1f28
+
+selection_foreground #c8c093
+selection_background #2d4f67
+
+url_color #7e9cd8
+
+cursor #dcd7ba
+cursor_text_color #1f1f28
+
+# Black
+color0 #090618
+color8 #727169
+
+# Red
+color1 #c34043
+color9 #e82424
+
+# Green
+color2 #76946a
+color10 #98bb6c
+
+# Yellow
+color3 #c0a36e
+color11 #e6c384
+
+# Blue
+color4 #7e9cd8
+color12 #7fb4ca
+
+# Magenta
+color5 #957fb8
+color13 #938aa9
+
+# Cyan
+color6 #6a9589
+color14 #7aa89f
+
+# White
+color7 #c8c093
+color15 #dcd7ba

--- a/themes/material/kitty.conf
+++ b/themes/material/kitty.conf
@@ -1,0 +1,45 @@
+# Material color scheme for kitty terminal emulator
+# Based on the colors defined in alacritty.toml
+
+foreground #B0BEC5
+background #263238
+
+selection_foreground #B0BEC5
+selection_background #37474F
+
+url_color #82aaff
+
+cursor #B0BEC5
+cursor_text_color #263238
+
+# Black
+color0 #1E272C
+color8 #1E272C
+
+# Red
+color1 #f07178
+color9 #f07178
+
+# Green
+color2 #c3e88d
+color10 #c3e88d
+
+# Yellow
+color3 #ffcb6b
+color11 #ffcb6b
+
+# Blue
+color4 #82aaff
+color12 #82aaff
+
+# Magenta
+color5 #c792ea
+color13 #c792ea
+
+# Cyan
+color6 #89ddff
+color14 #89ddff
+
+# White
+color7 #eeffff
+color15 #eeffff

--- a/themes/matte-black/kitty.conf
+++ b/themes/matte-black/kitty.conf
@@ -1,0 +1,45 @@
+# Matte Black color scheme for kitty terminal emulator
+# Based on the colors defined in alacritty.toml
+
+foreground #bebebe
+background #121212
+
+selection_foreground #bebebe
+selection_background #333333
+
+url_color #e68e0d
+
+cursor #eaeaea
+cursor_text_color #121212
+
+# Black
+color0 #333333
+color8 #8a8a8d
+
+# Red
+color1 #D35F5F
+color9 #B91C1C
+
+# Green
+color2 #FFC107
+color10 #FFC107
+
+# Yellow
+color3 #b91c1c
+color11 #b90a0a
+
+# Blue
+color4 #e68e0d
+color12 #f59e0b
+
+# Magenta
+color5 #D35F5F
+color13 #B91C1C
+
+# Cyan
+color6 #bebebe
+color14 #eaeaea
+
+# White
+color7 #bebebe
+color15 #ffffff

--- a/themes/nord/kitty.conf
+++ b/themes/nord/kitty.conf
@@ -1,0 +1,43 @@
+# Nord Colorscheme for Kitty
+# Based on:
+# - https://gist.github.com/marcusramberg/64010234c95a93d953e8c79fdaf94192
+# - https://github.com/arcticicestudio/nord-hyper
+
+foreground            #D8DEE9
+background            #2E3440
+selection_foreground  #000000
+selection_background  #FFFACD
+url_color             #0087BD
+cursor                #81A1C1
+
+# black
+color0   #3B4252
+color8   #4C566A
+
+# red
+color1   #BF616A
+color9   #BF616A
+
+# green
+color2   #A3BE8C
+color10  #A3BE8C
+
+# yellow
+color3   #EBCB8B
+color11  #EBCB8B
+
+# blue
+color4  #81A1C1
+color12 #81A1C1
+
+# magenta
+color5   #B48EAD
+color13  #B48EAD
+
+# cyan
+color6   #88C0D0
+color14  #8FBCBB
+
+# white
+color7   #E5E9F0
+color15  #ECEFF4

--- a/themes/osaka-jade/kitty.conf
+++ b/themes/osaka-jade/kitty.conf
@@ -1,0 +1,43 @@
+## name :osaka-jade
+foreground              #C1C497
+background              #111C18
+selection_foreground    #111C18
+selection_background    #C1C497
+cursor                  #D7C995
+cursor_text_color       #000000
+active_tab_foreground   #111C18
+active_tab_background   #C1C497
+inactive_tab_foreground #C1C497
+inactive_tab_background #111C18
+
+# black
+color0  #23372B
+color8  #53685B
+
+# red
+color1  #FF5345
+color9  #DB9F9C
+
+# green
+color2  #549E6A
+color10 #63b07a
+
+# yellow
+color3  #459451
+color11 #E5C736
+
+# blue
+color4  #509475
+color12 #ACD4CF
+
+# magenta
+color5  #D2689C
+color13 #75BBB3
+
+# cyan
+color6  #2DD5B7
+color14 #8CD3CB
+
+# white
+color7  #F6F5DD
+color15 #9EEBB3

--- a/themes/ristretto/kitty.conf
+++ b/themes/ristretto/kitty.conf
@@ -1,0 +1,45 @@
+# Ristretto color scheme for kitty terminal emulator
+# Based on the colors defined in alacritty.toml
+
+foreground #e6d9db
+background #2c2525
+
+selection_foreground #e6d9db
+selection_background #403e41
+
+url_color #f38d70
+
+cursor #c3b7b8
+cursor_text_color #2c2525
+
+# Black
+color0 #72696a
+color8 #948a8b
+
+# Red
+color1 #fd6883
+color9 #ff8297
+
+# Green
+color2 #adda78
+color10 #c8e292
+
+# Yellow
+color3 #f9cc6c
+color11 #fcd675
+
+# Blue
+color4 #f38d70
+color12 #f8a788
+
+# Magenta
+color5 #a8a9eb
+color13 #bebffd
+
+# Cyan
+color6 #85dacc
+color14 #9bf1e1
+
+# White
+color7 #e6d9db
+color15 #f1e5e7

--- a/themes/rose-pine/kitty.conf
+++ b/themes/rose-pine/kitty.conf
@@ -1,0 +1,55 @@
+## name: Rosé Pine
+## author: mvllow
+## license: MIT
+## upstream: https://github.com/rose-pine/kitty/blob/main/dist/rose-pine.conf
+## blurb: All natural pine, faux fur and a bit of soho vibes for the classy minimalist
+
+foreground               #e0def4
+background               #191724
+selection_foreground     #e0def4
+selection_background     #403d52
+
+cursor                   #524f67
+cursor_text_color        #e0def4
+
+url_color                #c4a7e7
+
+active_tab_foreground    #e0def4
+active_tab_background    #26233a
+inactive_tab_foreground  #6e6a86
+inactive_tab_background  #191724
+
+active_border_color      #31748f
+inactive_border_color    #403d52
+
+# black
+color0   #26233a
+color8   #6e6a86
+
+# red
+color1   #eb6f92
+color9   #eb6f92
+
+# green
+color2   #31748f
+color10  #31748f
+
+# yellow
+color3   #f6c177
+color11  #f6c177
+
+# blue
+color4   #9ccfd8
+color12  #9ccfd8
+
+# magenta
+color5   #c4a7e7
+color13  #c4a7e7
+
+# cyan
+color6   #ebbcba
+color14  #ebbcba
+
+# white
+color7   #e0def4
+color15  #e0def4

--- a/themes/tokyo-night/kitty.conf
+++ b/themes/tokyo-night/kitty.conf
@@ -1,0 +1,77 @@
+# Tokyo Night color scheme for kitty terminal emulator
+# https://github.com/davidmathers/tokyo-night-kitty-theme
+#
+# Based on Tokyo Night color theme for Visual Studio Code
+# https://github.com/enkia/tokyo-night-vscode-theme
+
+foreground #a9b1d6
+background #1a1b26
+
+# Black
+color0 #414868
+color8 #414868
+
+# Red
+color1 #f7768e
+color9 #f7768e
+
+# Green
+color2  #73daca
+color10 #73daca
+
+# Yellow
+color3  #e0af68
+color11 #e0af68
+
+# Blue
+color4  #7aa2f7
+color12 #7aa2f7
+
+# Magenta
+color5  #bb9af7
+color13 #bb9af7
+
+# Cyan
+color6  #7dcfff
+color14 #7dcfff
+
+# White
+color7  #c0caf5
+color15 #c0caf5
+
+# Cursor
+cursor #c0caf5
+cursor_text_color #1a1b26
+
+# Selection highlight
+selection_foreground none
+selection_background #28344a
+
+# The color for highlighting URLs on mouse-over
+url_color #9ece6a
+
+# Window borders
+active_border_color #3d59a1
+inactive_border_color #101014
+bell_border_color #e0af68
+
+# Tab bar
+tab_bar_style fade
+tab_fade 1
+active_tab_foreground   #3d59a1
+active_tab_background   #16161e
+active_tab_font_style   bold
+inactive_tab_foreground #787c99
+inactive_tab_background #16161e
+inactive_tab_font_style bold
+tab_bar_background #101014
+
+# Title bar
+macos_titlebar_color #16161e
+
+# Storm
+# background #24283b
+# cursor_text_color #24283b
+# active_tab_background   #1f2335
+# inactive_tab_background #1f2335
+# macos_titlebar_color #1f2335

--- a/themes/vancouver/kitty.conf
+++ b/themes/vancouver/kitty.conf
@@ -1,0 +1,45 @@
+# Vancouver color scheme for kitty terminal emulator
+# Based on the colors defined in vancouver.lua
+
+foreground #f0f0f0
+background #2a2a2a
+
+selection_foreground #f0f0f0
+selection_background #4a4a4a
+
+url_color #a9cce3
+
+cursor #f0f0f0
+cursor_text_color #2a2a2a
+
+# Black
+color0 #888888
+color8 #aaaaaa
+
+# Red
+color1 #f5b7b1
+color9 #ff8781
+
+# Green
+color2 #a3e4d7
+color10 #b3f4e7
+
+# Yellow
+color3 #f9e79f
+color11 #fff7af
+
+# Blue
+color4 #a9cce3
+color12 #b9ddf3
+
+# Magenta
+color5 #d7bde2
+color13 #e7cde2
+
+# Cyan
+color6 #a2d9ce
+color14 #b2e9de
+
+# White
+color7 #f0f0f0
+color15 #f0f0f0


### PR DESCRIPTION
This change introduces support for theming the kitty terminal within the existing theming framework.

- A base `kitty.conf` is added to `config/kitty/` which enables remote control and includes the user's personal settings for fonts, keybindings, and other preferences.
- The `install/config/theme.sh` script is updated to create a symlink for the kitty theme, pointing to the current theme's `kitty.conf`.
- `kitty.conf` files have been added to all existing theme directories, with color schemes derived from their respective palettes.
- The `hypr-theme-set` script is updated to reload the kitty theme using `kitty @ set-colors` when the system theme is changed, ensuring a seamless experience.