### PR TITLE
fix(theme): Reload Kitty config with SIGUSR1 for proper theming

### DIFF
--- a/bin/hypr-theme-set
+++ b/bin/hypr-theme-set
@@ -97,7 +97,7 @@ touch "$HOME/.config/alacritty/alacritty.toml"
 
 # Reload kitty config
 if pgrep -x kitty >/dev/null; then
-  kitty @ set-colors --all --configured "$CURRENT_THEME_DIR/kitty.conf"
+  pkill -SIGUSR1 -x kitty
 fi
 
 # Restart components to apply new theme


### PR DESCRIPTION
The previous method of reloading the Kitty theme using `kitty @ set-colors --configured` was not reliably applying the full theme, as it only handles color properties. This could leave other theme aspects, like directory colors, unchanged.

This change replaces the `kitty @ set-colors` command with `pkill -SIGUSR1 -x kitty`. Sending the SIGUSR1 signal is the official method recommended by Kitty's documentation to trigger a full configuration reload. This ensures that all theme settings, not just colors, are correctly applied to running instances when the system theme is switched.